### PR TITLE
remove edit and delete buttons for google cards

### DIFF
--- a/components/RestaurantCard.js
+++ b/components/RestaurantCard.js
@@ -51,10 +51,14 @@ export default function RestaurantCard({ restaurantObj, onUpdate }) {
         <div className="card-actions justify-end">
           {restaurantObj.userList !== user.uid
             ? <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=24717&format=png&color=000000" alt="add icon" width="20" /></button> : <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=1504&format=png&color=000000" alt="add icon" width="20" /></button> }
-          <Link href={`/restaurant/edit/${restaurantObj.firebaseKey}`} passHref>
-            <button type="button" className="btn-nobkgrd"><img className="btn-image" src="https://img.icons8.com/?size=100&id=15049&format=png&color=000000" alt="edit icon" width="20" /></button>
-          </Link>
-          <button type="button" className="btn-nobkgrd" onClick={deleteRestaurant}><img className="btn-image" src="https://img.icons8.com/?size=100&id=99933&format=png&color=000000" alt="delete icon" width="20" /></button>
+          {restaurantObj.userList
+            ? (
+              <Link href={`/restaurant/edit/${restaurantObj.firebaseKey}`} passHref>
+                <button type="button" className="btn-nobkgrd"><img className="btn-image" src="https://img.icons8.com/?size=100&id=15049&format=png&color=000000" alt="edit icon" width="20" /></button>
+              </Link>
+            ) : '' }
+          {!restaurantObj.id
+            ? <button type="button" className="btn-nobkgrd" onClick={deleteRestaurant}><img className="btn-image" src="https://img.icons8.com/?size=100&id=99933&format=png&color=000000" alt="delete icon" width="20" /></button> : ''}
 
         </div>
       </div>
@@ -74,6 +78,7 @@ RestaurantCard.propTypes = {
     cuisineId: PropTypes.string,
     tried: PropTypes.bool,
     primaryType: PropTypes.string,
+    id: PropTypes.string,
   }).isRequired,
   onUpdate: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
## Description
Added ternaries to remove the edit and delete buttons from google cards that are on the all restaurants page.

## Related Issue
#46 

## Motivation and Context
This change will prevent users from deleting restaurants from the main database.

## How Can This Be Tested?
Login ->
Navigate to all restaurants page ->
Confirm there are no edit or delete buttons

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
