### PR TITLE
Add api to eat list

### DIFF
--- a/api/eatListData.js
+++ b/api/eatListData.js
@@ -78,10 +78,23 @@ const updateEatListRestaurants = (payload) => new Promise((resolve, reject) => {
     .catch(reject);
 });
 
+const deleteRestFromEatList = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/eatlistRestaurants/${firebaseKey}.json`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => resolve(data))
+    .catch(reject);
+});
+
 export {
   getSingleEatList,
   getEatListRestaurants,
   getUserEatList,
   addToEatList,
   updateEatListRestaurants,
+  deleteRestFromEatList,
 };

--- a/components/RestaurantCard.js
+++ b/components/RestaurantCard.js
@@ -39,10 +39,10 @@ export default function RestaurantCard({ restaurantObj, onUpdate }) {
       }
     });
 
-    if (!onUserList) {
+    if (!onUserList && restaurantObj.id) {
       const payload = { ...restaurantObj, tried: false };
       createRestaurant(payload).then(({ name: restaurantFirebaseKey }) => {
-        const patchPayload = { firebaseKey: restaurantFirebaseKey };
+        const patchPayload = { firebaseKey: restaurantFirebaseKey, name: restaurantObj.displayName.text };
         updateRestaurant(patchPayload).then(() => {
           const payloadEatList = { eatListId: userEatList[0].firebaseKey, restaurantId: restaurantFirebaseKey };
           addToEatList(payloadEatList).then(({ name: eatListFirebaseKey }) => {
@@ -51,6 +51,14 @@ export default function RestaurantCard({ restaurantObj, onUpdate }) {
               onUpdate();
             });
           });
+        });
+      });
+    } if (!onUserList && restaurantObj.firebaseKey) {
+      const payloadEatList = { eatListId: userEatList[0].firebaseKey, restaurantId: restaurantObj.firebaseKey };
+      addToEatList(payloadEatList).then(({ name: firebaseKey }) => {
+        const patchPayload = { firebaseKey };
+        updateEatListRestaurants(patchPayload).then(() => {
+          onUpdate();
         });
       });
     } else {
@@ -90,8 +98,12 @@ export default function RestaurantCard({ restaurantObj, onUpdate }) {
           ))}
         </div>
         <div className="card-actions justify-end">
-          {restaurantObj.userList !== user.uid
-            ? <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=24717&format=png&color=000000" alt="add icon" width="20" /></button> : <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=1504&format=png&color=000000" alt="add icon" width="20" /></button> }
+          {userEatListRestaurants.map((restaurant) => (
+            restaurant.restaurantId === restaurantObj.firebaseKey ? <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=1504&format=png&color=000000" alt="add icon" width="20" /></button> : <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=24717&format=png&color=000000" alt="add icon" width="20" /></button>
+          ))}
+          {/* {restaurantObj.userList !== user.uid
+            ? <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=24717&format=png&color=000000" alt="add icon" width="20" /></button> : <button type="button" className="btn-nobkgrd" onClick={toggleToUserList}><img className="btn-image" src="https://img.icons8.com/?size=100&id=1504&format=png&color=000000" alt="add icon" width="20" /></button> } */}
+
           {restaurantObj.userList
             ? (
               <Link href={`/restaurant/edit/${restaurantObj.firebaseKey}`} passHref>

--- a/pages/restaurant/allRestaurants.js
+++ b/pages/restaurant/allRestaurants.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import RestaurantCard from '../../components/RestaurantCard';
 import getGoogleRestaurants from '../../api/externalRestaurantAPI';
+import { getRestaurants } from '../../api/restaurantData';
 
 const defineGoogleCuisine = (restaurantObj) => {
   const googleRestaurantObj = { ...restaurantObj };
@@ -49,14 +50,16 @@ const defineGoogleCuisine = (restaurantObj) => {
   return googleRestaurantObj;
 };
 export default function AllRestaurants() {
+  const [googleRestaurants, setGoogleRestaurants] = useState([]);
   const [restaurants, setRestaurants] = useState([]);
 
   const getAllRestaurants = () => {
     getGoogleRestaurants()
       .then((fetchedRestaurants) => {
         const updatedRestaurants = fetchedRestaurants.map((restaurant) => defineGoogleCuisine(restaurant));
-        setRestaurants(updatedRestaurants);
+        setGoogleRestaurants(updatedRestaurants);
       });
+    getRestaurants().then(setRestaurants);
   };
 
   useEffect(() => {
@@ -69,8 +72,10 @@ export default function AllRestaurants() {
         All Restaurants
       </h1>
       <div className="d-flex flex-wrap">
-        {restaurants.map((restaurant) => (
+        {googleRestaurants.map((restaurant) => (
           <RestaurantCard restaurantObj={restaurant} key={restaurant.id} onUpdate={getAllRestaurants} />))}
+        {restaurants.map((restaurant) => (
+          <RestaurantCard restaurantObj={restaurant} key={restaurant.firebaseKey} onUpdate={getAllRestaurants} />))}
       </div>
     </div>
   );

--- a/pages/restaurant/myRestaurants.js
+++ b/pages/restaurant/myRestaurants.js
@@ -21,6 +21,7 @@ export default function MyRestaurants() {
   const getAllUserRestaurants = (eatListId) => getAllEatListRestaurants(eatListId).then((list) => {
     setUserRestaurants(list.restaurants);
     setFilteredRestaurants(list.restaurants);
+    console.warn(list.restaurants);
   });
 
   useEffect(() => {

--- a/pages/restaurant/myRestaurants.js
+++ b/pages/restaurant/myRestaurants.js
@@ -2,34 +2,43 @@ import React, { useEffect, useState } from 'react';
 import RestaurantCard from '../../components/RestaurantCard';
 import { useAuth } from '../../utils/context/authContext';
 import getAllEatListRestaurants from '../../api/mergedData';
-import { getUserEatList } from '../../api/eatListData';
+import { getEatListRestaurants, getUserEatList } from '../../api/eatListData';
 
 export default function MyRestaurants() {
   const [userRestaurants, setUserRestaurants] = useState([]);
   const [filteredRestaurants, setFilteredRestaurants] = useState(userRestaurants);
+  const [eatListId, setEatListId] = useState(null);
+  const [eatListRestaurantKeys, setEatListRestaurantsKeys] = useState([]);
   const { user } = useAuth();
 
   const getEatListId = () => {
     console.warn('user:', user.uid);
     return getUserEatList(user.uid)
       .then((eatList) => {
-        const eatListId = eatList[0].firebaseKey;
-        return eatListId;
+        const id = eatList[0].firebaseKey;
+        setEatListId(id);
+        return id;
       });
   };
 
-  const getAllUserRestaurants = (eatListId) => getAllEatListRestaurants(eatListId).then((list) => {
+  const getEatListRestaurantKeys = (id) => {
+    getEatListRestaurants(id).then(setEatListRestaurantsKeys);
+  };
+
+  const getAllUserRestaurants = (id) => getAllEatListRestaurants(id).then((list) => {
     setUserRestaurants(list.restaurants);
     setFilteredRestaurants(list.restaurants);
-    console.warn(list.restaurants);
   });
 
   useEffect(() => {
     getEatListId()
       // eslint-disable-next-line consistent-return
-      .then((eatListId) => {
-        if (eatListId) {
-          return getAllUserRestaurants(eatListId);
+      .then((id) => {
+        if (id) {
+          return Promise.all([
+            getAllUserRestaurants(id),
+            getEatListRestaurantKeys(id),
+          ]);
         }
       });
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -57,8 +66,17 @@ export default function MyRestaurants() {
         <button type="button" className="btn btn-accent navButton" id="all" onClick={filterMyList}>All</button>
       </div>
       <div className="d-flex flex-wrap">
+        {console.warn('eatlistrestkeysonmyrests', eatListRestaurantKeys)}
         {filteredRestaurants.map((userRestaurant) => (
-          <RestaurantCard restaurantObj={userRestaurant} key={userRestaurant.firebaseKey} onUpdate={getAllUserRestaurants} />))}
+          <RestaurantCard
+            restaurantObj={userRestaurant}
+            key={userRestaurant.firebaseKey}
+            onUpdate={getAllUserRestaurants}
+            userRestaurants={userRestaurants}
+            eatListId={eatListId}
+            eatListRestaurantKeys={eatListRestaurantKeys}
+          />
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
- updated/fixed add to eat list functionality for both custom cards and external api cards
- added onUserList function
- updated/fixed buttons on cards to show the + when the restaurant is not on the list and the - when the restaurant is on the list
## Related Issue
#47 

## Motivation and Context
This change was required to fix bugs that developed from adding an external API

## How Can This Be Tested?
Login ->
Navigate to myRestaurants page, confirm that all cards show a - button -> 
Navigate to all restaurants page, confirm that cards not on your list show a + button ->
Add a card to your list by clicking + ->
Confirm the card is now on your list under my restaurants page

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
